### PR TITLE
Enum twig extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+composer.lock
 /vendor/
+.idea/

--- a/Exception/ConstantIsFoundInFewRegisteredEnumTypesException.php
+++ b/Exception/ConstantIsFoundInFewRegisteredEnumTypesException.php
@@ -1,0 +1,20 @@
+<?php
+/*
+ * This file is part of the FreshDoctrineEnumBundle
+ *
+ * (c) Artem Genvald <genvaldartem@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Fresh\DoctrineEnumBundle\Exception;
+
+/**
+ * ValueIsFoundInFewRegisteredEnumTypesException
+ *
+ * @author Artem Genvald <genvaldartem@gmail.com>
+ */
+class ConstantIsFoundInFewRegisteredEnumTypesException extends \LogicException
+{
+}

--- a/Exception/ConstantIsNotFoundInAnyRegisteredEnumTypeException.php
+++ b/Exception/ConstantIsNotFoundInAnyRegisteredEnumTypeException.php
@@ -1,0 +1,20 @@
+<?php
+/*
+ * This file is part of the FreshDoctrineEnumBundle
+ *
+ * (c) Artem Genvald <genvaldartem@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Fresh\DoctrineEnumBundle\Exception;
+
+/**
+ * ValueIsNotFoundInAnyRegisteredEnumTypeException
+ *
+ * @author Artem Genvald <genvaldartem@gmail.com>
+ */
+class ConstantIsNotFoundInAnyRegisteredEnumTypeException extends \LogicException
+{
+}

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,19 +1,23 @@
 parameters:
+    twig.extension.enum_value.class: Fresh\DoctrineEnumBundle\Twig\Extension\EnumValueExtension
     twig.extension.readable_enum_value.class: Fresh\DoctrineEnumBundle\Twig\Extension\ReadableEnumValueExtension
     enum_type_guesser.class: Fresh\DoctrineEnumBundle\Form\EnumTypeGuesser
 
 services:
+    twig.extension.enum_value:
+        class: %twig.extension.enum_value.class%
+        arguments: [%doctrine.dbal.connection_factory.types%]
+        tags:
+            - { name: twig.extension }
+
     twig.extension.readable_enum_value:
         class: %twig.extension.readable_enum_value.class%
-        arguments:
-            - %doctrine.dbal.connection_factory.types%
+        arguments: [%doctrine.dbal.connection_factory.types%]
         tags:
             - { name: twig.extension }
 
     enum_type_guesser:
         class: %enum_type_guesser.class%
-        arguments:
-            - @doctrine
-            - %doctrine.dbal.connection_factory.types%
+        arguments: ["@doctrine", %doctrine.dbal.connection_factory.types%]
         tags:
             - { name: form.type_guesser }

--- a/Tests/DependencyInjection/FreshDoctrineEnumExtensionTest.php
+++ b/Tests/DependencyInjection/FreshDoctrineEnumExtensionTest.php
@@ -53,6 +53,7 @@ class FreshDoctrineEnumExtensionTest extends \PHPUnit_Framework_TestCase
         $this->container->compile();
 
         // Check that services have been loaded
+        $this->assertTrue($this->container->has('twig.extension.enum_value'));
         $this->assertTrue($this->container->has('twig.extension.readable_enum_value'));
         $this->assertTrue($this->container->has('enum_type_guesser'));
     }

--- a/Tests/Twig/Extension/EnumValueExtensionTest.php
+++ b/Tests/Twig/Extension/EnumValueExtensionTest.php
@@ -1,0 +1,140 @@
+<?php
+/*
+ * This file is part of the FreshDoctrineEnumBundle
+ *
+ * (c) Artem Genvald <genvaldartem@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Fresh\DoctrineEnumBundle\Tests\Twig\Extension;
+
+use Fresh\DoctrineEnumBundle\Fixtures\DBAL\Types\BasketballPositionType;
+use Fresh\DoctrineEnumBundle\Fixtures\DBAL\Types\MapLocationType;
+use Fresh\DoctrineEnumBundle\Twig\Extension\EnumValueExtension;
+
+/**
+ * ReadableEnumValueExtensionTest
+ *
+ * @author Artem Genvald <genvaldartem@gmail.com>
+ */
+class EnumValueExtensionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var EnumValueExtension $readableEnumValueExtension
+     */
+    private $enumValueExtension;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp()
+    {
+        $this->enumValueExtension = new EnumValueExtension([
+            'BasketballPositionType' => [
+                'class' => 'Fresh\DoctrineEnumBundle\Fixtures\DBAL\Types\BasketballPositionType'
+            ],
+            'MapLocationType'        => [
+                'class' => 'Fresh\DoctrineEnumBundle\Fixtures\DBAL\Types\MapLocationType'
+            ]
+        ]);
+    }
+
+    /**
+     * Test method getName
+     */
+    public function testGetName()
+    {
+        $this->assertEquals('ENUM Value', $this->enumValueExtension->getName());
+    }
+
+    /**
+     * Test method getFilters
+     */
+    public function testGetFilters()
+    {
+        $this->assertEquals(
+            ['enum' => new \Twig_Filter_Method($this->enumValueExtension, 'getEnumValue')],
+            $this->enumValueExtension->getFilters()
+        );
+    }
+
+    /**
+     * Test that method getReadableEnumValue returns expected readable value
+     *
+     * @param string $expectedReadableValue Expected readable value
+     * @param string $enumValue             Enum value
+     * @param string $enumType              Enum type
+     *
+     * @dataProvider dataProviderForGetReadableEnumValueTest
+     */
+    public function testGetReadableEnumValue($expectedReadableValue, $enumValue, $enumType)
+    {
+        $this->assertEquals(
+            $expectedReadableValue,
+            $this->enumValueExtension->getEnumValue($enumValue, $enumType)
+        );
+    }
+
+    /**
+     * Data provider for method getReadableEnumValue
+     *
+     * @return array
+     */
+    public function dataProviderForGetReadableEnumValueTest()
+    {
+        return [
+            ['PG', 'POINT_GUARD', 'BasketballPositionType'],
+            ['PG', 'POINT_GUARD', null],
+            ['C', 'CENTER', 'BasketballPositionType'],
+            ['C', 'CENTER', 'MapLocationType']
+        ];
+    }
+
+    /**
+     * Test that using readable ENUM value extension for ENUM type that is not registered
+     * throws EnumTypeIsNotRegisteredException
+     *
+     * @expectedException \Fresh\DoctrineEnumBundle\Exception\EnumTypeIsNotRegisteredException
+     */
+    public function testEnumTypeIsNotRegisteredException()
+    {
+        $this->enumValueExtension->getEnumValue('Pitcher', 'BaseballPositionType');
+    }
+
+    /**
+     * Test that using ENUM value that is found in few registered ENUM types
+     * throws ValueIsFoundInFewRegisteredEnumTypesException
+     *
+     * @expectedException \Fresh\DoctrineEnumBundle\Exception\ConstantIsFoundInFewRegisteredEnumTypesException
+     */
+    public function testConstantIsFoundInFewRegisteredEnumTypesException()
+    {
+        $this->enumValueExtension->getEnumValue('CENTER');
+    }
+
+    /**
+     * Test that using ENUM value that is not found in any registered ENUM type
+     * throws ValueIsNotFoundInAnyRegisteredEnumTypeException
+     *
+     * @expectedException \Fresh\DoctrineEnumBundle\Exception\ConstantIsNotFoundInAnyRegisteredEnumTypeException
+     */
+    public function testConstantIsNotFoundInAnyRegisteredEnumTypeException()
+    {
+        $this->enumValueExtension->getEnumValue('Z');
+    }
+
+    /**
+     * Test that using readable ENUM value extension without any registered ENUM type
+     * throws NoRegisteredEnumTypesException
+     *
+     * @expectedException \Fresh\DoctrineEnumBundle\Exception\NoRegisteredEnumTypesException
+     */
+    public function testNoRegisteredEnumTypesException()
+    {
+        // Create ReadableEnumValueExtension without any registered ENUM type
+        $extension = new EnumValueExtension([]);
+        $extension->getEnumValue('POINT_GUARD', 'BasketballPositionType');
+    }
+}

--- a/Twig/Extension/EnumValueExtension.php
+++ b/Twig/Extension/EnumValueExtension.php
@@ -13,15 +13,15 @@ namespace Fresh\DoctrineEnumBundle\Twig\Extension;
 use Fresh\DoctrineEnumBundle\DBAL\Types\AbstractEnumType;
 use Fresh\DoctrineEnumBundle\Exception\EnumTypeIsNotRegisteredException;
 use Fresh\DoctrineEnumBundle\Exception\NoRegisteredEnumTypesException;
-use Fresh\DoctrineEnumBundle\Exception\ValueIsFoundInFewRegisteredEnumTypesException;
-use Fresh\DoctrineEnumBundle\Exception\ValueIsNotFoundInAnyRegisteredEnumTypeException;
+use Fresh\DoctrineEnumBundle\Exception\ConstantIsFoundInFewRegisteredEnumTypesException;
+use Fresh\DoctrineEnumBundle\Exception\ConstantIsNotFoundInAnyRegisteredEnumTypeException;
 
 /**
- * ReadableEnumValueExtension returns the readable variant of ENUM value
+ * EnumValueExtension returns the readable variant of ENUM value
  *
  * @author Artem Genvald <genvaldartem@gmail.com>
  */
-class ReadableEnumValueExtension extends \Twig_Extension
+class EnumValueExtension extends \Twig_Extension
 {
     /**
      * @var AbstractEnumType[] $registeredEnumTypes Array of registered ENUM types
@@ -47,26 +47,24 @@ class ReadableEnumValueExtension extends \Twig_Extension
      */
     public function getFilters()
     {
-        return ['readable' => new \Twig_Filter_Method($this, 'getReadableEnumValue')];
+        return ['enum' => new \Twig_Filter_Method($this, 'getEnumValue')];
     }
 
     /**
-     * Get readable variant of ENUM value
+     * Get variant of ENUM value
      *
-     * @param string      $enumValue ENUM value
+     * @param string      $enumConst ENUM value
      * @param string|null $enumType  ENUM type
      *
      * @throws EnumTypeIsNotRegisteredException
      * @throws NoRegisteredEnumTypesException
-     * @throws ValueIsFoundInFewRegisteredEnumTypesException
-     * @throws ValueIsNotFoundInAnyRegisteredEnumTypeException
+     * @throws ConstantIsFoundInFewRegisteredEnumTypesException
+     * @throws ConstantIsNotFoundInAnyRegisteredEnumTypeException
      *
      * @return string
      */
-    public function getReadableEnumValue($enumValue, $enumType = null)
+    public function getEnumValue($enumConst, $enumType=null)
     {
-        $enumValue = (string) $enumValue;
-
         if (!empty($this->registeredEnumTypes) && is_array($this->registeredEnumTypes)) {
             // If ENUM type was set, e.g. {{ player.position|readable('BasketballPositionType') }}
             if (!empty($enumType)) {
@@ -77,34 +75,31 @@ class ReadableEnumValueExtension extends \Twig_Extension
                     ));
                 }
 
-                /** @var $enumTypeClass \Fresh\DoctrineEnumBundle\DBAL\Types\AbstractEnumType */
-                $enumTypeClass = $this->registeredEnumTypes[$enumType];
-
-                return $enumTypeClass::getReadableValue($enumValue);
+                return constant($this->registeredEnumTypes[$enumType].'::'.$enumConst);
             } else {
                 // If ENUM type wasn't set, e.g. {{ player.position|readable }}
                 $occurrences = [];
                 // Check if value exists in registered ENUM types
                 foreach ($this->registeredEnumTypes as $registeredEnumType) {
-                    if ($registeredEnumType::isValueExist($enumValue)) {
+                    $refl = new \ReflectionClass($registeredEnumType);
+                    if ($refl->hasConstant($enumConst)) {
                         $occurrences[] = $registeredEnumType;
                     }
                 }
 
                 // If found only one occurrence, then we know exactly which ENUM type
                 if (count($occurrences) == 1) {
-                    $enumTypeClass = array_pop($occurrences);
-
-                    return $enumTypeClass::getReadableValue($enumValue);
+                    $enumClassName = array_pop($occurrences);
+                    return constant($enumClassName.'::'.$enumConst);
                 } elseif (count($occurrences) > 1) {
-                    throw new ValueIsFoundInFewRegisteredEnumTypesException(sprintf(
-                        'Value "%s" is found in few registered ENUM types. You should manually set the appropriate one',
-                        $enumValue
+                    throw new ConstantIsFoundInFewRegisteredEnumTypesException(sprintf(
+                        'Constant "%s" is found in few registered ENUM types. You should manually set the appropriate one',
+                        $enumConst
                     ));
                 } else {
-                    throw new ValueIsNotFoundInAnyRegisteredEnumTypeException(sprintf(
-                        'Value "%s" wasn\'t found in any registered ENUM type',
-                        $enumValue
+                    throw new ConstantIsNotFoundInAnyRegisteredEnumTypeException(sprintf(
+                        'Constant "%s" wasn\'t found in any registered ENUM type',
+                        $enumConst
                     ));
                 }
             }
@@ -118,6 +113,6 @@ class ReadableEnumValueExtension extends \Twig_Extension
      */
     public function getName()
     {
-        return 'Readable ENUM Value';
+        return 'ENUM Value';
     }
 }


### PR DESCRIPTION
Done this some time ago, solves #22.

By this PR you can do
```twig
{% if order.status == 'ORDER_COMPLETE'|enum %}
    <a href="#"><i class="fa fa-check"></i> View details</a>
{% elseif order.status == 'ORDER_PENDING'|enum %}
    <a href="#"><i class="fa fa-refresh fa-spin"></i> View details</a>
{% elseif order.status == 'ORDER_ABORTED'|enum %}
    <a href="#"><i class="fa fa-exclamation"></i> View details</a>
{% endif %}
```

Before this PR you have to use the ```constant``` function with a long and ugly namespace
```twig
{% if order.status == constant('AcmeBundle\\DBAL\\Types\\OrderStatusEnum::ORDER_COMPLETE') %}
    <a href="#"><i class="fa fa-check"></i> View details</a>
{% elseif order.status == constant('AcmeBundle\\DBAL\\Types\\OrderStatusEnum::ORDER_PENDING') %}
    <a href="#"><i class="fa fa-refresh fa-spin"></i> View details</a>
{% elseif order.status == constant('AcmeBundle\\DBAL\\Types\\OrderStatusEnum::ORDER_ABORTED') %}
    <a href="#"><i class="fa fa-exclamation"></i> View details</a>
{% endif %}
```