### PR TITLE
Bump symfony to 3.0

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -21,7 +21,7 @@ services:
     enum_type_guesser:
         class: %enum_type_guesser.class%
         arguments:
-            - @doctrine
+            - "@doctrine"
             - %doctrine.dbal.connection_factory.types%
         tags:
             - { name: form.type_guesser }

--- a/Tests/Validator/EnumValidatorTest.php
+++ b/Tests/Validator/EnumValidatorTest.php
@@ -39,7 +39,7 @@ class EnumValidatorTest extends \PHPUnit_Framework_TestCase
     {
         $this->enumValidator = new EnumValidator();
 
-        $this->context = $this->getMockBuilder('Symfony\Component\Validator\ExecutionContext')
+        $this->context = $this->getMockBuilder('Symfony\Component\Validator\Context\ExecutionContext')
                               ->disableOriginalConstructor()
                               ->getMock();
     }
@@ -69,7 +69,7 @@ class EnumValidatorTest extends \PHPUnit_Framework_TestCase
 
         $this->context
              ->expects($this->never())
-             ->method('addViolation');
+             ->method('buildViolation');
 
         $this->enumValidator->initialize($this->context);
         $this->enumValidator->validate(BasketballPositionType::SMALL_FORWARD, $constraint);
@@ -84,13 +84,28 @@ class EnumValidatorTest extends \PHPUnit_Framework_TestCase
             'entity' => 'Fresh\DoctrineEnumBundle\Tests\Fixtures\DBAL\Types\BasketballPositionType',
         ]);
 
+        $constraintValidationBuilder = $this->getMockBuilder('Symfony\Component\Validator\Violation\ConstraintViolationBuilder')
+                                            ->disableOriginalConstructor()
+                                            ->getMock();
+
+        $constraintValidationBuilder
+            ->expects($this->once())
+            ->method('setParameter')
+            ->with(
+                $this->equalTo('{{ value }}'),
+                $this->equalTo('"Pitcher"')
+            )->will($this->returnSelf());
+
+        $constraintValidationBuilder
+            ->expects($this->once())
+            ->method('setCode')
+            ->will($this->returnSelf());
+
         $this->context
-             ->expects($this->once())
-             ->method('addViolation')
-             ->with(
-                 $this->equalTo('The value you selected is not a valid choice.'),
-                 $this->equalTo(['{{ value }}' => '"Pitcher"'])
-             );
+            ->expects($this->once())
+            ->method('buildViolation')
+            ->with($this->equalTo('The value you selected is not a valid choice.'))
+            ->will($this->returnValue($constraintValidationBuilder));
 
         $this->enumValidator->initialize($this->context);
         $this->enumValidator->validate('Pitcher', $constraint); // It's not a baseball =)

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "require": {
         "php": ">=5.4.0",
-        "symfony/symfony": "~2.3|~3.0",
+        "symfony/symfony": "~2.6|~3.0",
         "doctrine/orm": "~2.2"
     },
     "require-dev": {


### PR DESCRIPTION
Symfony 3.0 compatibility: 
  * `YamlFileParser` now requires service locators to be quoted
  * Bumped min symfony version to 2.6 due to `Symfony\Component\Validator\ExecutionContext` being replaced by `Symfony\Component\Validator\Context\ExecutionContext` (old class has now been removed), and its internal structure has also changed somewhat, hence the changes in mock objects on tests.