### PR TITLE
Fix checking symfony version in LegacyFormHelper

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Provides support of **ENUM type** for Doctrine in Symfony applications.
 
 | Bundle Version (X.Y) | PHP     | Symfony            | Doctrine | Comment                                   |
 |:--------------------:|:-------:|:------------------:|:--------:|:------------------------------------------|
-| 4.2                  | >= 5.4  | >= 2.6, >= 3.0     | >= 2.2   | Actual version                            |
+| 4.3                  | >= 5.4  | >= 2.6, >= 3.0     | >= 2.2   | Actual version                            |
 | 3.3                  | >= 5.4  | >= 2.3 and <= 2.8  | >= 2.2   |                                           |
 | 2.6                  | 5.3     | >= 2.3 and <= 2.7  | >= 2.2   | Frozen version, no longer being supported |
 

--- a/Tests/Util/LegacyFormHelperTest.php
+++ b/Tests/Util/LegacyFormHelperTest.php
@@ -65,6 +65,6 @@ class LegacyFormHelperTest extends \PHPUnit_Framework_TestCase
      */
     public function testExceptionForGetUnsupportedType()
     {
-        LegacyFormHelper::getType('Symfony\Component\Form\Extension\Core\Type\TextType');
+        LegacyFormHelper::getType('Symfony\Component\Form\Extension\Core\Type\TextType', 2);
     }
 }

--- a/Tests/Util/LegacyFormHelperTest.php
+++ b/Tests/Util/LegacyFormHelperTest.php
@@ -8,58 +8,63 @@
  * file that was distributed with this source code.
  */
 
-namespace Fresh\DoctrineEnumBundle\Tests\Util {
+namespace Fresh\DoctrineEnumBundle\Tests\Util;
 
-    use Fresh\DoctrineEnumBundle\Tests\Fixtures\DBAL\Types\BasketballPositionType;
-    use Fresh\DoctrineEnumBundle\Util\LegacyFormHelper;
+use Fresh\DoctrineEnumBundle\Util\LegacyFormHelper;
+
+/**
+ * LegacyFormHelperTest
+ *
+ * @author Jaik Dean <jaik@fluoresce.co>
+ * @author Artem Genvald <genvaldartem@gmail.com>
+ */
+class LegacyFormHelperTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider dataProviderForIsLegacyTest
+     */
+    public function testIsLegacy($majorVersion, $expectedLegacyStatus)
+    {
+        $this->assertEquals($expectedLegacyStatus, LegacyFormHelper::isLegacy($majorVersion));
+    }
+
+    public function dataProviderForIsLegacyTest()
+    {
+        return [
+            [1, true],
+            [2, true],
+            [3, false],
+        ];
+    }
 
     /**
-     * LegacyFormHelperTest
-     *
-     * @author Jaik Dean <jaik@fluoresce.co>
-     *
-     * @coversClass \Fresh\DoctrineEnumBundle\Util\LegacyFormHelper
+     * @dataProvider dataProviderForGetTypeTest
      */
-    class LegacyFormHelperTest extends \PHPUnit_Framework_TestCase
+    public function testGetType($majorVersion, $expectedFormType)
     {
-        /**
-         * Test that the helper identifies whether we’re running a legacy
-         * version of Symfony.
-         */
-        public function testIsLegacy()
-        {
-            global $LegacyFormHelperTest_legacySymfonyVersion;
-
-            $LegacyFormHelperTest_legacySymfonyVersion = true;
-            $this->assertEquals(true, LegacyFormHelper::isLegacy());
-
-            $LegacyFormHelperTest_legacySymfonyVersion = false;
-            $this->assertEquals(false, LegacyFormHelper::isLegacy());
-        }
-
-        /**
-         * Test that the correct form field type is returned for current and legacy
-         * versions of Symfony.
-         */
-        public function testGetType()
-        {
-            global $LegacyFormHelperTest_legacySymfonyVersion;
-            $formType = 'Symfony\Component\Form\Extension\Core\Type\ChoiceType';
-
-            $LegacyFormHelperTest_legacySymfonyVersion = true;
-            $this->assertEquals('choice', LegacyFormHelper::getType($formType));
-
-            $LegacyFormHelperTest_legacySymfonyVersion = false;
-            $this->assertEquals($formType, LegacyFormHelper::getType($formType));
-        }
+        $this->assertEquals(
+            $expectedFormType,
+            LegacyFormHelper::getType('Symfony\Component\Form\Extension\Core\Type\ChoiceType', $majorVersion)
+        );
     }
-}
 
-namespace Fresh\DoctrineEnumBundle\Util {
-
-    function method_exists($class, $method)
+    /**
+     * @return array
+     */
+    public function dataProviderForGetTypeTest()
     {
-        global $LegacyFormHelperTest_legacySymfonyVersion;
-        return !$LegacyFormHelperTest_legacySymfonyVersion;
+        return [
+            [2, 'choice'],
+            [3, 'Symfony\Component\Form\Extension\Core\Type\ChoiceType'],
+        ];
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Form type with class "Symfony\Component\Form\Extension\Core\Type\TextType" can not be found. Please check for typos or add it to the map in LegacyFormHelper
+     */
+    public function testExceptionForGetUnsupportedType()
+    {
+        LegacyFormHelper::getType('Symfony\Component\Form\Extension\Core\Type\TextType');
     }
 }

--- a/Util/LegacyFormHelper.php
+++ b/Util/LegacyFormHelper.php
@@ -10,35 +10,53 @@
 
 namespace Fresh\DoctrineEnumBundle\Util;
 
+use Symfony\Component\HttpKernel\Kernel;
+
 /**
- * This class was based on LegacyFormHelper in FOSUserBundle:
- * https://github.com/FriendsOfSymfony/FOSUserBundle/blob/c533a233b52c1d3843e816a35677561330ddbc74/Util/LegacyFormHelper.php
+ * LegacyFormHelper
+ *
+ * This class based on LegacyFormHelper in FOSUserBundle:
+ * @see https://github.com/FriendsOfSymfony/FOSUserBundle/blob/c533a233b52c1d3843e816a35677561330ddbc74/Util/LegacyFormHelper.php
  *
  * @internal
  *
  * @author Gabor Egyed <gabor.egyed@gmail.com>
  * @author Jaik Dean <jaik@fluoresce.co>
+ * @author Artem Genvald <genvaldartem@gmail.com>
  */
 final class LegacyFormHelper
 {
-    private static $map = array(
+    const MINIMUM_MAJOR_VERSION = 3;
+
+    /**
+     * @var array $map Mapping form type classes to legacy form types
+     * @static
+     */
+    private static $map = [
         'Symfony\Component\Form\Extension\Core\Type\ChoiceType' => 'choice',
-    );
+    ];
 
     /**
      * Get a form field type compatible with the current version of Symfony
      *
-     * @param string $class
+     * @param string $class        Class
+     * @param int    $majorVersion Major version
+     *
      * @return string Class or type name
      */
-    public static function getType($class)
+    public static function getType($class, $majorVersion = Kernel::MAJOR_VERSION)
     {
-        if (!self::isLegacy()) {
+        if (!self::isLegacy($majorVersion)) {
             return $class;
         }
 
         if (!isset(self::$map[$class])) {
-            throw new \InvalidArgumentException(sprintf('Form type with class "%s" can not be found. Please check for typos or add it to the map in LegacyFormHelper', $class));
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'Form type with class "%s" can not be found. Please check for typos or add it to the map in LegacyFormHelper',
+                    $class
+                )
+            );
         }
 
         return self::$map[$class];
@@ -47,18 +65,14 @@ final class LegacyFormHelper
     /**
      * Check whether to use legacy form behaviour from Symfony <3.0
      *
+     * @param int $majorVersion Major version
+     *
+     * @static
+     *
      * @return bool
      */
-    public static function isLegacy()
+    public static function isLegacy($majorVersion = Kernel::MAJOR_VERSION)
     {
-        return !method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix');
-    }
-
-    private function __construct()
-    {
-    }
-
-    private function __clone()
-    {
+        return $majorVersion < self::MINIMUM_MAJOR_VERSION;
     }
 }


### PR DESCRIPTION
The previous logic was to check if `getBlockPrefix` exists in `Symfony\Component\Form\AbstractType`.
But this method is present in 3.0 version and also in 2.8. For version 2.8 LegacyFormHelper also flipped array of choices, so compatibility with version 2.8 was broken. I decided to use Kernel::MAJOR_VERSION for checking legacy.