### PR TITLE
Quote strings starting '%' in YAML

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -5,23 +5,23 @@ parameters:
 
 services:
     twig.extension.readable_enum_value:
-        class: %twig.extension.readable_enum_value.class%
+        class: "%twig.extension.readable_enum_value.class%"
         arguments:
-            - %doctrine.dbal.connection_factory.types%
+            - "%doctrine.dbal.connection_factory.types%"
         tags:
             - { name: twig.extension }
 
     twig.extension.enum_constant:
-        class: %twig.extension.enum_constant.class%
+        class: "%twig.extension.enum_constant.class%"
         arguments:
-            - %doctrine.dbal.connection_factory.types%
+            - "%doctrine.dbal.connection_factory.types%"
         tags:
             - { name: twig.extension }
 
     enum_type_guesser:
-        class: %enum_type_guesser.class%
+        class: "%enum_type_guesser.class%"
         arguments:
             - "@doctrine"
-            - %doctrine.dbal.connection_factory.types%
+            - "%doctrine.dbal.connection_factory.types%"
         tags:
             - { name: form.type_guesser }


### PR DESCRIPTION
As of Symfony 3.1, having unquoted scalars starting with “%” in YAML is deprecated, and will throw an exception in Symfony 4.0. This PR adds quotes where necessary.