### PR TITLE
Set minimum twig version to 1.26

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "symfony/framework-bundle": "~2.6|~3.0",
         "symfony/http-kernel": "~2.6|~3.0",
         "symfony/validator": "~2.6|~3.0",
-        "twig/twig": "~1.13"
+        "twig/twig": "~1.26"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.8",


### PR DESCRIPTION
After the fix #68 bundle cannot work with Twig < 1.26. Current fix changes the minimum required version of Twig to 1.26.
If you need to work with the Twig less than 1.26 use tag 4.6.4

Fixes #75 