### PR TITLE
Add function getReadableValues in AbstractEnumType

### DIFF
--- a/DBAL/Types/AbstractEnumType.php
+++ b/DBAL/Types/AbstractEnumType.php
@@ -127,6 +127,18 @@ abstract class AbstractEnumType extends Type
     }
 
     /**
+     * Get array of ENUM Values, where ENUM values are keys and their readable versions are values.
+     *
+     * @static
+     *
+     * @return array Array of values with readable format
+     */
+    public static function getReadableValues()
+    {
+        return static::$choices;
+    }
+
+    /**
      * Get value in readable format.
      *
      * @param string $value ENUM value
@@ -150,6 +162,8 @@ abstract class AbstractEnumType extends Type
      * Check if some string value exists in the array of ENUM values.
      *
      * @param string $value ENUM value
+     *
+     * @static
      *
      * @return bool
      */

--- a/Tests/DBAL/Types/AbstractEnumTypeTest.php
+++ b/Tests/DBAL/Types/AbstractEnumTypeTest.php
@@ -114,6 +114,18 @@ class AbstractEnumTypeTest extends \PHPUnit_Framework_TestCase
         $this->type->convertToDatabaseValue('YO', new MySqlPlatform());
     }
 
+    public function testGetReadableValues()
+    {
+        $choices = [
+            'PG' => 'Point Guard',
+            'SG' => 'Shooting Guard',
+            'SF' => 'Small Forward',
+            'PF' => 'Power Forward',
+            'C'  => 'Center',
+        ];
+        $this->assertEquals($choices, $this->type->getReadableValues());
+    }
+
     public function testGetReadableValue()
     {
         $this->assertEquals('Small Forward', $this->type->getReadableValue(BasketballPositionType::SMALL_FORWARD));


### PR DESCRIPTION
This function may be very useful.
For example, SonataAdminBundle (v3.9) in ListMapper uses choices for 'choice' type in this format. (It looks like a bug - FormMapper uses a new format of choices, but ListMapper uses old format.)