### PR TITLE
Add handling for mapped database types in MySQL

### DIFF
--- a/DBAL/Types/AbstractEnumType.php
+++ b/DBAL/Types/AbstractEnumType.php
@@ -11,7 +11,7 @@
 namespace Fresh\DoctrineEnumBundle\DBAL\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;

--- a/DBAL/Types/AbstractEnumType.php
+++ b/DBAL/Types/AbstractEnumType.php
@@ -11,6 +11,7 @@
 namespace Fresh\DoctrineEnumBundle\DBAL\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Platforms\SQLServerPlatform;
@@ -164,5 +165,26 @@ abstract class AbstractEnumType extends Type
     public static function isValueExist($value)
     {
         return isset(static::$choices[$value]);
+    }
+    
+    /**
+     * Gets an array of database types that map to this Doctrine type.
+     *
+     * @param \Doctrine\DBAL\Platforms\AbstractPlatform $platform
+     *
+     * @return array
+     */
+    public function getMappedDatabaseTypes(AbstractPlatform $platform)
+    {
+        if ($platform instanceof MySqlPlatform) {
+            return array_merge(
+                parent::getMappedDatabaseTypes($platform),
+                [
+                    'enum',
+                ]
+            );
+        }
+        
+        return parent::getMappedDatabaseTypes($platform);
     }
 }

--- a/DBAL/Types/AbstractEnumType.php
+++ b/DBAL/Types/AbstractEnumType.php
@@ -166,7 +166,7 @@ abstract class AbstractEnumType extends Type
     {
         return isset(static::$choices[$value]);
     }
-    
+
     /**
      * Gets an array of database types that map to this Doctrine type.
      *
@@ -184,7 +184,7 @@ abstract class AbstractEnumType extends Type
                 ]
             );
         }
-        
+
         return parent::getMappedDatabaseTypes($platform);
     }
 }

--- a/Tests/DBAL/Types/AbstractEnumTypeTest.php
+++ b/Tests/DBAL/Types/AbstractEnumTypeTest.php
@@ -145,4 +145,24 @@ class AbstractEnumTypeTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($choices, $this->type->getChoices());
     }
+    
+    public function testMappedDatabaseTypesContainEnumOnMySQL()
+    {
+        $actual = $this->type->getMappedDatabaseTypes(new MySqlPlatform());
+        $this->assertContains('enum', $actual);
+    }
+    
+    public function testMappedDatabaseTypesDoesNotContainEnumOnNonMySQL()
+    {
+        $testProviders = [
+            new SqlitePlatform(),
+            new PostgreSqlPlatform(),
+            new SQLServerPlatform(),
+        ];
+        
+        foreach ($testProviders as $testProvider) {
+            $actual = $this->type->getMappedDatabaseTypes($testProvider);
+            $this->assertNotContains('enum', $actual);
+        }
+    }
 }


### PR DESCRIPTION
Before doctrine:migrations:diff fails with the error "Unknown database type enum requested, Doctrine\DBAL\Platforms\MySqlPlatform may not support it." because the ENUM MySQL column type was not mapped to the AbstractEnumType.
Adding the ENUM MySQL column type allows the doctrine migrations to identify diffs correctly resulting in working creation of diffs with already existing ENUM columns in tables.