### PR TITLE
Add support for multiple level inheritance in form type guesser

### DIFF
--- a/Form/EnumTypeGuesser.php
+++ b/Form/EnumTypeGuesser.php
@@ -86,7 +86,7 @@ class EnumTypeGuesser extends DoctrineOrmTypeGuesser
 
         $abstractEnumTypeFQCN = 'Fresh\DoctrineEnumBundle\DBAL\Types\AbstractEnumType';
 
-        if (get_parent_class($registeredEnumTypeFQCN) !== $abstractEnumTypeFQCN) {
+        if (!is_subclass_of($registeredEnumTypeFQCN, $abstractEnumTypeFQCN)) {
             return;
         }
 

--- a/Tests/Fixtures/DBAL/Types/AbstractParentType.php
+++ b/Tests/Fixtures/DBAL/Types/AbstractParentType.php
@@ -1,0 +1,22 @@
+<?php
+/*
+ * This file is part of the FreshDoctrineEnumBundle
+ *
+ * (c) Artem Genvald <genvaldartem@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Fresh\DoctrineEnumBundle\Tests\Fixtures\DBAL\Types;
+
+use Fresh\DoctrineEnumBundle\DBAL\Types\AbstractEnumType;
+
+/**
+ * AbstractParentType.
+ *
+ * @author Arturs Vonda <github@artursvonda.lv>
+ */
+abstract class AbstractParentType extends AbstractEnumType
+{
+}

--- a/Tests/Fixtures/DBAL/Types/InheritedType.php
+++ b/Tests/Fixtures/DBAL/Types/InheritedType.php
@@ -1,0 +1,28 @@
+<?php
+/*
+ * This file is part of the FreshDoctrineEnumBundle
+ *
+ * (c) Artem Genvald <genvaldartem@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Fresh\DoctrineEnumBundle\Tests\Fixtures\DBAL\Types;
+
+/**
+ * InheritedType.
+ *
+ * @author Arturs Vonda <github@artursvonda.lv>
+ */
+final class InheritedType extends AbstractParentType
+{
+    protected $name = 'InheritedType';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected static $choices = [
+        'foo' => 'bar',
+    ];
+}


### PR DESCRIPTION
This allows applications to define app level base type to extend without losing automatically guessed form type.

Fixes #60 