### PR TITLE
Add method AbstractEnumType::assertValidChoice()

### DIFF
--- a/DBAL/Types/AbstractEnumType.php
+++ b/DBAL/Types/AbstractEnumType.php
@@ -20,7 +20,7 @@ use Doctrine\DBAL\Types\Type;
 /**
  * AbstractEnumType.
  *
- * Provides support of MySQL ENUM type for Doctrine in Symfony applications.
+ * Provides support of ENUM type for Doctrine in Symfony applications.
  *
  * @author Artem Genvald <genvaldartem@gmail.com>
  * @author Ben Davies <ben.davies@gmail.com>
@@ -134,6 +134,20 @@ abstract class AbstractEnumType extends Type
     }
 
     /**
+     * Asserts that given choice exists in the array of ENUM values.
+     *
+     * @param string $value ENUM value
+     *
+     * @throws \InvalidArgumentException
+     */
+    public static function assertValidChoice($value)
+    {
+        if (!isset(static::$choices[$value])) {
+            throw new \InvalidArgumentException(sprintf('Invalid value "%s" for ENUM type "%s".', $value, get_called_class()));
+        }
+    }
+
+    /**
      * Get value in readable format.
      *
      * @param string $value ENUM value
@@ -146,9 +160,7 @@ abstract class AbstractEnumType extends Type
      */
     public static function getReadableValue($value)
     {
-        if (!isset(static::$choices[$value])) {
-            throw new \InvalidArgumentException(sprintf('Invalid value "%s" for ENUM type "%s".', $value, get_called_class()));
-        }
+        static::assertValidChoice($value);
 
         return static::$choices[$value];
     }

--- a/Tests/DBAL/Types/AbstractEnumTypeTest.php
+++ b/Tests/DBAL/Types/AbstractEnumTypeTest.php
@@ -120,6 +120,19 @@ class AbstractEnumTypeTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($choices, $this->type->getReadableValues());
     }
 
+    public function testAssertValidChoice()
+    {
+        $this->assertNull($this->type->assertValidChoice(BasketballPositionType::SMALL_FORWARD));
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testInvalidArgumentExceptionInAssertValidChoice()
+    {
+        $this->type->assertValidChoice('YO');
+    }
+
     public function testGetReadableValue()
     {
         $this->assertEquals('Small Forward', $this->type->getReadableValue(BasketballPositionType::SMALL_FORWARD));
@@ -145,13 +158,13 @@ class AbstractEnumTypeTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($choices, $this->type->getChoices());
     }
-    
+
     public function testMappedDatabaseTypesContainEnumOnMySQL()
     {
         $actual = $this->type->getMappedDatabaseTypes(new MySqlPlatform());
         $this->assertContains('enum', $actual);
     }
-    
+
     public function testMappedDatabaseTypesDoesNotContainEnumOnNonMySQL()
     {
         $testProviders = [
@@ -159,7 +172,7 @@ class AbstractEnumTypeTest extends \PHPUnit_Framework_TestCase
             new PostgreSqlPlatform(),
             new SQLServerPlatform(),
         ];
-        
+
         foreach ($testProviders as $testProvider) {
             $actual = $this->type->getMappedDatabaseTypes($testProvider);
             $this->assertNotContains('enum', $actual);


### PR DESCRIPTION
I want to use this in setter like this:

```php
class Player
{
    /**
     * @ORM\Column(name="position", type="BasketballPositionType", nullable=false)
     */
    protected $position;

    public function setPosition(string $position)
    {
        BasketballPositionType::assertValidChoice($position);
        $this->position = $position;
    }
}
```

Or if nullable:

```php
class Player
{
    /**
     * @ORM\Column(name="position", type="BasketballPositionType", nullable=true)
     */
    protected $position;

    public function setPosition(?string $position)
    {
        if ($position !== null) {
            BasketballPositionType::assertValidChoice($position);
        }

        $this->position = $position;
    }
}
```