### PR TITLE
Fix: database to php convert with numeric choice indexes

### DIFF
--- a/DBAL/Types/AbstractEnumType.php
+++ b/DBAL/Types/AbstractEnumType.php
@@ -61,6 +61,25 @@ abstract class AbstractEnumType extends Type
     /**
      * {@inheritdoc}
      */
+    public function convertToPHPValue($value, AbstractPlatform $platform)
+    {
+        if (!isset(static::$choices[$value])) {
+            return $value;
+        }
+
+        // Check whether choice list is using integers as valies
+        $choice = static::$choices[$value];
+        $choices = array_flip(static::$choices);
+        if (is_int($choices[$choice])) {
+            return (int) $value;
+        }
+
+        return $value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getSqlDeclaration(array $fieldDeclaration, AbstractPlatform $platform): string
     {
         $values = \implode(

--- a/Tests/DBAL/Types/AbstractEnumTypeTest.php
+++ b/Tests/DBAL/Types/AbstractEnumTypeTest.php
@@ -20,6 +20,7 @@ use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\DBAL\Types\Type;
 use Fresh\DoctrineEnumBundle\DBAL\Types\AbstractEnumType;
 use Fresh\DoctrineEnumBundle\Tests\Fixtures\DBAL\Types\BasketballPositionType;
+use Fresh\DoctrineEnumBundle\Tests\Fixtures\DBAL\Types\NumericType;
 use Fresh\DoctrineEnumBundle\Tests\Fixtures\DBAL\Types\StubType;
 use PHPUnit\Framework\TestCase;
 
@@ -38,6 +39,7 @@ class AbstractEnumTypeTest extends TestCase
     {
         Type::addType('BasketballPositionType', BasketballPositionType::class);
         Type::addType('StubType', StubType::class);
+        Type::addType('NumericType', NumericType::class);
     }
 
     public function setUp()
@@ -178,5 +180,15 @@ class AbstractEnumTypeTest extends TestCase
             $actual = $this->type->getMappedDatabaseTypes($testProvider);
             $this->assertNotContains('enum', $actual);
         }
+    }
+
+    public function testConvertToPHPValue()
+    {
+        $this->assertNull($this->type->convertToPHPValue(null, new MySqlPlatform()));
+        $this->assertSame('SF', $this->type->convertToPHPValue('SF', new MySqlPlatform()));
+
+        $this->type = Type::getType('NumericType');
+        $this->assertNull($this->type->convertToPHPValue(null, new MySqlPlatform()));
+        $this->assertEquals(1, $this->type->convertToPHPValue('1', new MySqlPlatform()));
     }
 }

--- a/Tests/Fixtures/DBAL/Types/NumericType.php
+++ b/Tests/Fixtures/DBAL/Types/NumericType.php
@@ -1,0 +1,37 @@
+<?php
+/*
+ * This file is part of the FreshDoctrineEnumBundle
+ *
+ * (c) Artem Henvald <genvaldartem@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Fresh\DoctrineEnumBundle\Tests\Fixtures\DBAL\Types;
+
+use Fresh\DoctrineEnumBundle\DBAL\Types\AbstractEnumType;
+
+/**
+ * NumericType.
+ *
+ * @author Stephan Vock <stephan.vock@gmail.com>
+ */
+final class NumericType extends AbstractEnumType
+{
+    public const ZERO = 0;
+    public const ONE = 1;
+    public const TWO = 2;
+    public const THREE = 3;
+    public const FOUR = 4;
+
+    protected $name = 'NumericType';
+
+    protected static $choices = [
+        self::ZERO => 0,
+        self::ONE => 1,
+        self::TWO => 2,
+        self::THREE => 3,
+        self::FOUR => 4,
+    ];
+}


### PR DESCRIPTION
This PR addresses the following issues: https://github.com/EasyCorp/EasyAdminBundle/issues/2089 and https://github.com/fre5h/DoctrineEnumBundle/issues/122

The problem is that if you are using integer values as choice indexes fetching the data from the database will always set them as a string value on the Entity.