### PR TITLE
Fix enum_constant function for non-string enum values

### DIFF
--- a/Twig/Extension/EnumConstantTwigExtension.php
+++ b/Twig/Extension/EnumConstantTwigExtension.php
@@ -52,14 +52,14 @@ class EnumConstantTwigExtension extends AbstractEnumTwigExtension
             if (null !== $enumType) {
                 $this->throwExceptionIfEnumTypeIsNotRegistered($enumType);
 
-                return (string)\constant($this->registeredEnumTypes[$enumType].'::'.$enumConstant);
+                return (string) \constant($this->registeredEnumTypes[$enumType].'::'.$enumConstant);
             }
 
             // If ENUM type wasn't set, e.g. {{ 'CENTER'|enum_constant }}
             $this->findOccurrences($enumConstant);
 
             if ($this->onlyOneOccurrenceFound()) {
-                return (string)\constant(\array_pop($this->occurrences).'::'.$enumConstant);
+                return (string) \constant(\array_pop($this->occurrences).'::'.$enumConstant);
             }
 
             if ($this->moreThanOneOccurrenceFound()) {

--- a/Twig/Extension/EnumConstantTwigExtension.php
+++ b/Twig/Extension/EnumConstantTwigExtension.php
@@ -52,14 +52,14 @@ class EnumConstantTwigExtension extends AbstractEnumTwigExtension
             if (null !== $enumType) {
                 $this->throwExceptionIfEnumTypeIsNotRegistered($enumType);
 
-                return \constant($this->registeredEnumTypes[$enumType].'::'.$enumConstant);
+                return (string)\constant($this->registeredEnumTypes[$enumType].'::'.$enumConstant);
             }
 
             // If ENUM type wasn't set, e.g. {{ 'CENTER'|enum_constant }}
             $this->findOccurrences($enumConstant);
 
             if ($this->onlyOneOccurrenceFound()) {
-                return \constant(\array_pop($this->occurrences).'::'.$enumConstant);
+                return (string)\constant(\array_pop($this->occurrences).'::'.$enumConstant);
             }
 
             if ($this->moreThanOneOccurrenceFound()) {


### PR DESCRIPTION
Hi thanks for your work,

Today I was migrating an application to symfony 4 and I noticed that we had a crash on this function. It was caused because the values of our enumType were integer instead of string, I think that this PR will fix it, if you think that is not good solution I can try to think in another one.

Thanks,

Regards.