### PR TITLE
Support doctrine/doctrine-bundle:2.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "require": {
         "php": ">=7.1.3",
-        "doctrine/doctrine-bundle": "~1.11",
+        "doctrine/doctrine-bundle": "~1.11 || ^2.0",
         "doctrine/common": "~2.8",
         "doctrine/orm": "~2.6",
         "symfony/config": "^4.3",
@@ -40,7 +40,8 @@
         "phpstan/phpstan-doctrine":"^0.11",
         "phpstan/phpstan-phpunit": "^0.11",
         "phpunit/phpunit": "^7.5",
-        "symfony/form": "^4.3"
+        "symfony/form": "^4.3",
+        "symfony/yaml": "^4.3"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
All that was required to get the test suite passing was requiring `symfony/yaml` in dev.