### PR TITLE
Improve AbstractEnumType Types | Enable PHPStan-Doctrine Usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /vendor/
+.phpunit.result.cache
+composer.lock

--- a/Command/EnumDropCommentCommand.php
+++ b/Command/EnumDropCommentCommand.php
@@ -159,7 +159,7 @@ HELP
 
             $io->title(\sprintf('Dropping comments for <info>%s</info> type...', $this->enumType));
 
-            /** @var \Doctrine\ORM\Mapping\ClassMetadata[] $allMetadata */
+            /** @var \Doctrine\ORM\Mapping\ClassMetadata<object>[] $allMetadata */
             $allMetadata = $this->em->getMetadataFactory()->getAllMetadata();
 
             if (!empty($allMetadata)) {

--- a/DBAL/Types/AbstractEnumType.php
+++ b/DBAL/Types/AbstractEnumType.php
@@ -29,6 +29,8 @@ use Fresh\DoctrineEnumBundle\Exception\InvalidArgumentException;
  * @author Artem Henvald <genvaldartem@gmail.com>
  * @author Ben Davies <ben.davies@gmail.com>
  * @author Jaik Dean <jaik@fluoresce.co>
+ *
+ * @template T of int|string
  */
 abstract class AbstractEnumType extends Type
 {
@@ -36,7 +38,7 @@ abstract class AbstractEnumType extends Type
     protected $name = '';
 
     /**
-     * @var array|mixed[] Array of ENUM Values, where ENUM values are keys and their readable versions are values
+     * @var array<T, T> Array of ENUM Values, where ENUM values are keys and their readable versions are values
      *
      * @static
      */
@@ -46,6 +48,8 @@ abstract class AbstractEnumType extends Type
      * {@inheritdoc}
      *
      * @throws InvalidArgumentException
+     *
+     * @return T|null
      */
     public function convertToDatabaseValue($value, AbstractPlatform $platform)
     {
@@ -62,6 +66,8 @@ abstract class AbstractEnumType extends Type
 
     /**
      * {@inheritdoc}
+     *
+     * @return T|null
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
@@ -155,7 +161,7 @@ abstract class AbstractEnumType extends Type
      *
      * @static
      *
-     * @return mixed[] Values for the ENUM field
+     * @return list<T> Values for the ENUM field
      */
     public static function getValues(): array
     {
@@ -167,7 +173,7 @@ abstract class AbstractEnumType extends Type
      *
      * @static
      *
-     * @return int|string
+     * @return T
      */
     public static function getRandomValue()
     {
@@ -182,7 +188,7 @@ abstract class AbstractEnumType extends Type
      *
      * @static
      *
-     * @return mixed[] Array of values in readable format
+     * @return array<T, T> Array of values in readable format
      */
     public static function getReadableValues(): array
     {
@@ -192,7 +198,7 @@ abstract class AbstractEnumType extends Type
     /**
      * Asserts that given choice exists in the array of ENUM values.
      *
-     * @param mixed $value ENUM value
+     * @param T $value ENUM value
      *
      * @throws InvalidArgumentException
      */
@@ -206,11 +212,11 @@ abstract class AbstractEnumType extends Type
     /**
      * Get value in readable format.
      *
-     * @param mixed $value ENUM value
+     * @param T $value ENUM value
      *
      * @static
      *
-     * @return mixed Value in readable format
+     * @return T Value in readable format
      */
     public static function getReadableValue($value)
     {
@@ -220,9 +226,9 @@ abstract class AbstractEnumType extends Type
     }
 
     /**
-     * Check if some string value exists in the array of ENUM values.
+     * Check if some value exists in the array of ENUM values.
      *
-     * @param mixed $value ENUM value
+     * @param T $value ENUM value
      *
      * @static
      *

--- a/DBAL/Types/AbstractEnumType.php
+++ b/DBAL/Types/AbstractEnumType.php
@@ -30,7 +30,7 @@ use Fresh\DoctrineEnumBundle\Exception\InvalidArgumentException;
  * @author Ben Davies <ben.davies@gmail.com>
  * @author Jaik Dean <jaik@fluoresce.co>
  *
- * @template T of int|string
+ * @template T
  */
 abstract class AbstractEnumType extends Type
 {
@@ -79,7 +79,7 @@ abstract class AbstractEnumType extends Type
         $choice = static::$choices[$value];
         $choices = \array_flip(static::$choices);
         if (\is_int($choices[$choice])) {
-            return (int) $value;
+            return (int) $value; // @phpstan-ignore-line T can be int
         }
 
         return $value;
@@ -161,7 +161,7 @@ abstract class AbstractEnumType extends Type
      *
      * @static
      *
-     * @return list<T> Values for the ENUM field
+     * @return mixed[] Values for the ENUM field
      */
     public static function getValues(): array
     {
@@ -188,7 +188,7 @@ abstract class AbstractEnumType extends Type
      *
      * @static
      *
-     * @return array<T, T> Array of values in readable format
+     * @return mixed[] Array of values in readable format
      */
     public static function getReadableValues(): array
     {
@@ -198,7 +198,7 @@ abstract class AbstractEnumType extends Type
     /**
      * Asserts that given choice exists in the array of ENUM values.
      *
-     * @param T $value ENUM value
+     * @param int|string $value ENUM value
      *
      * @throws InvalidArgumentException
      */
@@ -212,7 +212,7 @@ abstract class AbstractEnumType extends Type
     /**
      * Get value in readable format.
      *
-     * @param T $value ENUM value
+     * @param int|string $value ENUM value
      *
      * @static
      *
@@ -228,7 +228,7 @@ abstract class AbstractEnumType extends Type
     /**
      * Check if some value exists in the array of ENUM values.
      *
-     * @param T $value ENUM value
+     * @param int|string $value ENUM value
      *
      * @static
      *

--- a/DBAL/Types/DayOfWeekFullNameType.php
+++ b/DBAL/Types/DayOfWeekFullNameType.php
@@ -16,6 +16,8 @@ namespace Fresh\DoctrineEnumBundle\DBAL\Types;
  * DayOfWeekFullNameType.
  *
  * @author Artem Henvald <genvaldartem@gmail.com>
+ *
+ * @extends AbstractEnumType<string>
  */
 final class DayOfWeekFullNameType extends AbstractEnumType
 {

--- a/DBAL/Types/DayOfWeekShortNameType.php
+++ b/DBAL/Types/DayOfWeekShortNameType.php
@@ -16,6 +16,8 @@ namespace Fresh\DoctrineEnumBundle\DBAL\Types;
  * DayOfWeekShortNameType.
  *
  * @author Artem Henvald <genvaldartem@gmail.com>
+ *
+ * @extends AbstractEnumType<string>
  */
 final class DayOfWeekShortNameType extends AbstractEnumType
 {

--- a/DBAL/Types/MonthFullNameType.php
+++ b/DBAL/Types/MonthFullNameType.php
@@ -16,6 +16,8 @@ namespace Fresh\DoctrineEnumBundle\DBAL\Types;
  * MonthFullNameType.
  *
  * @author Artem Henvald <genvaldartem@gmail.com>
+ *
+ * @extends AbstractEnumType<string>
  */
 final class MonthFullNameType extends AbstractEnumType
 {

--- a/DBAL/Types/MonthShortNameType.php
+++ b/DBAL/Types/MonthShortNameType.php
@@ -16,6 +16,8 @@ namespace Fresh\DoctrineEnumBundle\DBAL\Types;
  * MonthShortNameType.
  *
  * @author Artem Henvald <genvaldartem@gmail.com>
+ *
+ * @extends AbstractEnumType<string>
  */
 final class MonthShortNameType extends AbstractEnumType
 {

--- a/Form/EnumTypeGuesser.php
+++ b/Form/EnumTypeGuesser.php
@@ -61,7 +61,7 @@ class EnumTypeGuesser extends DoctrineOrmTypeGuesser
             return null;
         }
 
-        /** @var \Doctrine\ORM\Mapping\ClassMetadataInfo $metadata */
+        /** @var \Doctrine\ORM\Mapping\ClassMetadataInfo<object> $metadata */
         [$metadata] = $classMetadata;
         $fieldType = $metadata->getTypeOfField($property);
 
@@ -86,7 +86,7 @@ class EnumTypeGuesser extends DoctrineOrmTypeGuesser
             return null;
         }
 
-        /** @var AbstractEnumType $registeredEnumTypeFQCN */
+        /** @var AbstractEnumType<int|string> $registeredEnumTypeFQCN */
         $parameters = [
             'choices' => $registeredEnumTypeFQCN::getChoices(), // Get the choices from the fully qualified class name
             'required' => !$metadata->isNullable($property),

--- a/Tests/Fixtures/DBAL/Types/AbstractParentType.php
+++ b/Tests/Fixtures/DBAL/Types/AbstractParentType.php
@@ -18,6 +18,10 @@ use Fresh\DoctrineEnumBundle\DBAL\Types\AbstractEnumType;
  * AbstractParentType.
  *
  * @author Arturs Vonda <github@artursvonda.lv>
+ *
+ * @template T of int|string
+ *
+ * @extends AbstractEnumType<T>
  */
 abstract class AbstractParentType extends AbstractEnumType
 {

--- a/Tests/Fixtures/DBAL/Types/BasketballPositionType.php
+++ b/Tests/Fixtures/DBAL/Types/BasketballPositionType.php
@@ -18,6 +18,8 @@ use Fresh\DoctrineEnumBundle\DBAL\Types\AbstractEnumType;
  * BasketballPositionType.
  *
  * @author Artem Henvald <genvaldartem@gmail.com>
+ *
+ * @extends AbstractEnumType<string>
  */
 final class BasketballPositionType extends AbstractEnumType
 {

--- a/Tests/Fixtures/DBAL/Types/InheritedType.php
+++ b/Tests/Fixtures/DBAL/Types/InheritedType.php
@@ -16,6 +16,8 @@ namespace Fresh\DoctrineEnumBundle\Tests\Fixtures\DBAL\Types;
  * InheritedType.
  *
  * @author Arturs Vonda <github@artursvonda.lv>
+ *
+ * @extends AbstractParentType<string>
  */
 final class InheritedType extends AbstractParentType
 {

--- a/Tests/Fixtures/DBAL/Types/MapLocationType.php
+++ b/Tests/Fixtures/DBAL/Types/MapLocationType.php
@@ -18,6 +18,8 @@ use Fresh\DoctrineEnumBundle\DBAL\Types\AbstractEnumType;
  * MapLocationType.
  *
  * @author Artem Henvald <genvaldartem@gmail.com>
+ *
+ * @extends AbstractEnumType<string>
  */
 final class MapLocationType extends AbstractEnumType
 {

--- a/Tests/Fixtures/DBAL/Types/NumericType.php
+++ b/Tests/Fixtures/DBAL/Types/NumericType.php
@@ -18,6 +18,8 @@ use Fresh\DoctrineEnumBundle\DBAL\Types\AbstractEnumType;
  * NumericType.
  *
  * @author Stephan Vock <stephan.vock@gmail.com>
+ *
+ * @extends AbstractEnumType<int>
  */
 final class NumericType extends AbstractEnumType
 {

--- a/Tests/Fixtures/DBAL/Types/StubType.php
+++ b/Tests/Fixtures/DBAL/Types/StubType.php
@@ -18,6 +18,8 @@ use Fresh\DoctrineEnumBundle\DBAL\Types\AbstractEnumType;
  * StubType.
  *
  * @author Artem Henvald <genvaldartem@gmail.com>
+ *
+ * @extends AbstractEnumType<string>
  */
 final class StubType extends AbstractEnumType
 {

--- a/Tests/Fixtures/DBAL/Types/TaskStatusType.php
+++ b/Tests/Fixtures/DBAL/Types/TaskStatusType.php
@@ -18,6 +18,8 @@ use Fresh\DoctrineEnumBundle\DBAL\Types\AbstractEnumType;
  * TaskStatusType.
  *
  * @author Artem Henvald <genvaldartem@gmail.com>
+ *
+ * @extends AbstractEnumType<string>
  */
 final class TaskStatusType extends AbstractEnumType
 {

--- a/Tests/Twig/Extension/ReadableEnumValueTwigExtensionTest.php
+++ b/Tests/Twig/Extension/ReadableEnumValueTwigExtensionTest.php
@@ -18,6 +18,7 @@ use Fresh\DoctrineEnumBundle\Exception\EnumValue\ValueIsFoundInFewRegisteredEnum
 use Fresh\DoctrineEnumBundle\Exception\EnumValue\ValueIsNotFoundInAnyRegisteredEnumTypeException;
 use Fresh\DoctrineEnumBundle\Tests\Fixtures\DBAL\Types\BasketballPositionType;
 use Fresh\DoctrineEnumBundle\Tests\Fixtures\DBAL\Types\MapLocationType;
+use Fresh\DoctrineEnumBundle\Tests\Fixtures\DBAL\Types\NumericType;
 use Fresh\DoctrineEnumBundle\Twig\Extension\ReadableEnumValueTwigExtension;
 use PHPUnit\Framework\TestCase;
 use Twig\TwigFilter;
@@ -37,6 +38,7 @@ final class ReadableEnumValueTwigExtensionTest extends TestCase
         $this->readableEnumValueTwigExtension = new ReadableEnumValueTwigExtension([
             'BasketballPositionType' => ['class' => BasketballPositionType::class],
             'MapLocationType' => ['class' => MapLocationType::class],
+            'NumericType' => ['class' => NumericType::class],
         ]);
     }
 
@@ -56,11 +58,11 @@ final class ReadableEnumValueTwigExtensionTest extends TestCase
     /**
      * @dataProvider dataProviderForGetReadableEnumValueTest
      *
-     * @param string|null $expectedReadableValue
-     * @param string|null $enumValue
+     * @param int|string|null $expectedReadableValue
+     * @param int|string|null $enumValue
      * @param string|null $enumType
      */
-    public function testGetReadableEnumValue(?string $expectedReadableValue, ?string $enumValue, ?string $enumType): void
+    public function testGetReadableEnumValue($expectedReadableValue, $enumValue, ?string $enumType): void
     {
         self::assertEquals(
             $expectedReadableValue,
@@ -75,6 +77,8 @@ final class ReadableEnumValueTwigExtensionTest extends TestCase
         yield ['Center', BasketballPositionType::CENTER, 'BasketballPositionType'];
         yield ['Center', MapLocationType::CENTER, 'MapLocationType'];
         yield [null, null, 'MapLocationType'];
+        yield [1, NumericType::ONE, 'NumericType'];
+        yield [1, NumericType::ONE, null];
     }
 
     public function testEnumTypeIsNotRegisteredException(): void

--- a/Twig/Extension/AbstractEnumTwigExtension.php
+++ b/Twig/Extension/AbstractEnumTwigExtension.php
@@ -24,10 +24,10 @@ use Twig\Extension\AbstractExtension;
  */
 abstract class AbstractEnumTwigExtension extends AbstractExtension
 {
-    /** @var string[]|AbstractEnumType[] */
+    /** @var string[]|AbstractEnumType<int|string>[] */
     protected $registeredEnumTypes = [];
 
-    /** @var string[]|AbstractEnumType[] */
+    /** @var string[]|AbstractEnumType<int|string>[] */
     protected $occurrences = [];
 
     /**

--- a/Twig/Extension/EnumConstantTwigExtension.php
+++ b/Twig/Extension/EnumConstantTwigExtension.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Fresh\DoctrineEnumBundle\Twig\Extension;
 
+use Fresh\DoctrineEnumBundle\DBAL\Types\AbstractEnumType;
 use Fresh\DoctrineEnumBundle\Exception\Constant\ConstantIsFoundInFewRegisteredEnumTypesException;
 use Fresh\DoctrineEnumBundle\Exception\Constant\ConstantIsNotFoundInAnyRegisteredEnumTypeException;
 use Fresh\DoctrineEnumBundle\Exception\EnumType\EnumTypeIsNotRegisteredException;
@@ -88,7 +89,7 @@ class EnumConstantTwigExtension extends AbstractEnumTwigExtension
      */
     private function findOccurrences(string $enumConstant): void
     {
-        /** @var class-string<\Fresh\DoctrineEnumBundle\DBAL\Types\AbstractEnumType> $registeredEnumType */
+        /** @var class-string<AbstractEnumType<int|string>> $registeredEnumType */
         foreach ($this->registeredEnumTypes as $registeredEnumType) {
             $reflection = new \ReflectionClass($registeredEnumType);
 

--- a/Twig/Extension/ReadableEnumValueTwigExtension.php
+++ b/Twig/Extension/ReadableEnumValueTwigExtension.php
@@ -35,7 +35,7 @@ class ReadableEnumValueTwigExtension extends AbstractEnumTwigExtension
     }
 
     /**
-     * @param string|null $enumValue
+     * @param int|string|null $enumValue
      * @param string|null $enumType
      *
      * @throws EnumTypeIsNotRegisteredException
@@ -45,7 +45,7 @@ class ReadableEnumValueTwigExtension extends AbstractEnumTwigExtension
      *
      * @return int|string|null
      */
-    public function getReadableEnumValue(?string $enumValue, ?string $enumType = null)
+    public function getReadableEnumValue($enumValue, ?string $enumType = null)
     {
         if ($this->hasRegisteredEnumTypes()) {
             if (null === $enumValue) {
@@ -91,9 +91,9 @@ class ReadableEnumValueTwigExtension extends AbstractEnumTwigExtension
     }
 
     /**
-     * @param string $enumValue
+     * @param int|string $enumValue
      */
-    private function findOccurrences(string $enumValue): void
+    private function findOccurrences($enumValue): void
     {
         foreach ($this->registeredEnumTypes as $registeredEnumType) {
             if ($registeredEnumType::isValueExist($enumValue)) {

--- a/Twig/Extension/ReadableEnumValueTwigExtension.php
+++ b/Twig/Extension/ReadableEnumValueTwigExtension.php
@@ -43,9 +43,9 @@ class ReadableEnumValueTwigExtension extends AbstractEnumTwigExtension
      * @throws ValueIsFoundInFewRegisteredEnumTypesException
      * @throws ValueIsNotFoundInAnyRegisteredEnumTypeException
      *
-     * @return string|null
+     * @return int|string|null
      */
-    public function getReadableEnumValue(?string $enumValue, ?string $enumType = null): ?string
+    public function getReadableEnumValue(?string $enumValue, ?string $enumType = null)
     {
         if ($this->hasRegisteredEnumTypes()) {
             if (null === $enumValue) {

--- a/Twig/Extension/ReadableEnumValueTwigExtension.php
+++ b/Twig/Extension/ReadableEnumValueTwigExtension.php
@@ -36,7 +36,7 @@ class ReadableEnumValueTwigExtension extends AbstractEnumTwigExtension
 
     /**
      * @param int|string|null $enumValue
-     * @param string|null $enumType
+     * @param string|null     $enumType
      *
      * @throws EnumTypeIsNotRegisteredException
      * @throws NoRegisteredEnumTypesException

--- a/Validator/Constraints/Enum.php
+++ b/Validator/Constraints/Enum.php
@@ -24,7 +24,7 @@ use Symfony\Component\Validator\Constraints\Choice;
  */
 class Enum extends Choice
 {
-    /** @var string|AbstractEnumType */
+    /** @var string|AbstractEnumType<int|string> */
     public $entity;
 
     /**
@@ -35,7 +35,7 @@ class Enum extends Choice
         $this->strict = true;
 
         if (isset($options['entity'])) {
-            /** @var AbstractEnumType $entity */
+            /** @var AbstractEnumType<int|string> $entity */
             $entity = $options['entity'];
 
             if (\is_subclass_of($entity, AbstractEnumType::class)) {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,4 +11,3 @@ parameters:
         - '%rootDir%/../../../vendor/*'
     fileExtensions:
         - 'php'
-    checkGenericClassInNonGenericObjectType: false


### PR DESCRIPTION
## Description

This PR solves #195 by providing types for the needed methods.

Users will be able to specify via generics annotations what kind of values will be in their custom type, with only `int` or `string` being allowed.

## Features/Changes

- [x] Added generics support in `AbstractEnumType`
- [x] Updated the type hints of some of the helper methods to use the template type instead of `mixed`
- [x] Provided types where needed in the codebase

## Testing
- [x] Tested these changes in a separate project that uses [phpstan-doctrine](https://github.com/phpstan/phpstan-doctrine). Users will be able to register their custom enum types using the [ReflectionDescriptor](https://github.com/phpstan/phpstan-doctrine#registering-type-descriptors)
- [x] Removed `checkGenericClassInNonGenericObjectType: false` and fixed PHPStan issues related to generics in this project