### PR TITLE
Fix docs according to the latest bundle updates

### DIFF
--- a/Resources/docs/default_value.md
+++ b/Resources/docs/default_value.md
@@ -16,7 +16,7 @@ final class MapLocationType extends AbstractEnumType
     public const WEST = 'W';
     public const CENTER = 'C';
 
-    protected static $choices = [
+    protected static array $choices = [
         self::NORTH => 'North',
         self::EAST => 'East',
         self::SOUTH => 'South',

--- a/Resources/docs/example_usage.md
+++ b/Resources/docs/example_usage.md
@@ -24,7 +24,7 @@ final class BasketballPositionType extends AbstractEnumType
     public const POWER_FORWARD = 'PF';
     public const CENTER = 'C';
 
-    protected static $choices = [
+    protected static array $choices = [
         self::POINT_GUARD => 'Point Guard',
         self::SHOOTING_GUARD => 'Shooting Guard',
         self::SMALL_FORWARD => 'Small Forward',


### PR DESCRIPTION
Have updated a bundle to the latest version and have got an error:
` #message: "Compile Error: Type of App\DBAL\Types\PaymentStatusType::$choices must be array (as in class Fresh\DoctrineEnumBundle\DBAL\Types\AbstractEnumType)"`
Property definition in parent class has changed but it is not reflected in the documentation.

This PR updates doc according to that issue.