### PR TITLE
fix(DBAL): handle Dbal 4.x EnumType

### DIFF
--- a/DependencyInjection/Compiler/RegisterEnumTypePass.php
+++ b/DependencyInjection/Compiler/RegisterEnumTypePass.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 
 namespace Fresh\DoctrineEnumBundle\DependencyInjection\Compiler;
 
+use Doctrine\DBAL\Types\EnumType;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\Persistence\ManagerRegistry;
 use Fresh\DoctrineEnumBundle\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
@@ -39,8 +41,9 @@ final class RegisterEnumTypePass implements CompilerPassInterface
         foreach ($doctrine->getConnectionNames() as $connectionName) {
             $definition = $container->getDefinition($connectionName);
             $mappingTypes = (array) $definition->getArgument(3);
-            if (!isset($mappingTypes['enum']) || 'string' !== $mappingTypes['enum']) {
-                $mappingTypes['enum'] = 'string';
+            $expectedType = class_exists(EnumType::class) ? Types::ENUM : 'string';
+            if (!isset($mappingTypes['enum']) || $expectedType !== $mappingTypes['enum']) {
+                $mappingTypes['enum'] = $expectedType;
                 $definition->setArgument(3, $mappingTypes);
             }
         }

--- a/Tests/DependencyInjection/Compiler/RegisterEnumTypePassTest.php
+++ b/Tests/DependencyInjection/Compiler/RegisterEnumTypePassTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Fresh\DoctrineEnumBundle\Tests\DependencyInjection\Compiler;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\Persistence\ManagerRegistry;
 use Fresh\DoctrineEnumBundle\DependencyInjection\Compiler\RegisterEnumTypePass;
 use Fresh\DoctrineEnumBundle\Exception\InvalidArgumentException;
@@ -79,7 +80,7 @@ final class RegisterEnumTypePassTest extends TestCase
         $default
             ->expects(self::once())
             ->method('setArgument')
-            ->with(3, ['test' => '_test', 'enum' => 'string'])
+            ->with(3, ['test' => '_test', 'enum' => Types::ENUM])
         ;
 
         $custom1 = $this->createMock(Definition::class);
@@ -92,7 +93,7 @@ final class RegisterEnumTypePassTest extends TestCase
         $custom1
             ->expects(self::once())
             ->method('setArgument')
-            ->with(3, ['test' => '_test', 'enum' => 'string'])
+            ->with(3, ['test' => '_test', 'enum' => Types::ENUM])
         ;
 
         $custom2 = $this->createMock(Definition::class);
@@ -100,7 +101,7 @@ final class RegisterEnumTypePassTest extends TestCase
             ->expects(self::once())
             ->method('getArgument')
             ->with(3)
-            ->willReturn(['test' => '_test', 'enum' => 'string'])
+            ->willReturn(['test' => '_test', 'enum' => Types::ENUM])
         ;
         $custom2
             ->expects(self::never())


### PR DESCRIPTION
Relates to https://github.com/fre5h/DoctrineEnumBundle/issues/228#issuecomment-2640721442.

At the moment, if you install DBAL 4.X, the migrate / dump-sql commands will display changes for every custom type, because the resolved SQL declaration is `VARCHAR(0) NOT NULL`. This PR fix this issue by using the native ENUM type from Doctrine