### PR TITLE
#245 - Mapping types are always the last argument

### DIFF
--- a/DependencyInjection/Compiler/RegisterEnumTypePass.php
+++ b/DependencyInjection/Compiler/RegisterEnumTypePass.php
@@ -41,11 +41,12 @@ final class RegisterEnumTypePass implements CompilerPassInterface
         /* @see \Doctrine\Bundle\DoctrineBundle\ConnectionFactory::createConnection */
         foreach ($doctrine->getConnectionNames() as $connectionName) {
             $definition = $container->getDefinition($connectionName);
-            $mappingTypes = (array) $definition->getArgument(3);
+            $lastArgument = count($definition->getArguments()) - 1;
+            $mappingTypes = (array) $definition->getArgument($lastArgument);
             $expectedType = class_exists(EnumType::class) ? Types::ENUM : 'string';
             if (!isset($mappingTypes['enum']) || $expectedType !== $mappingTypes['enum']) {
                 $mappingTypes['enum'] = $expectedType;
-                $definition->setArgument(3, $mappingTypes);
+                $definition->setArgument($lastArgument, $mappingTypes);
             }
         }
     }

--- a/Tests/DependencyInjection/Compiler/RegisterEnumTypePassTest.php
+++ b/Tests/DependencyInjection/Compiler/RegisterEnumTypePassTest.php
@@ -23,6 +23,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * RegisterEnumTypePassTest.
@@ -74,6 +75,16 @@ final class RegisterEnumTypePassTest extends TestCase
         $default = $this->createMock(Definition::class);
         $default
             ->expects(self::once())
+            ->method('getArguments')
+            ->willReturn([
+                ['url' => 'mysql:\\\\'],
+                new Reference('doctrine.dbal.default_connection.configuration'),
+                null,
+                [],
+            ])
+        ;
+        $default
+            ->expects(self::once())
             ->method('getArgument')
             ->with(3)
             ->willReturn(['test' => '_test'])
@@ -87,6 +98,16 @@ final class RegisterEnumTypePassTest extends TestCase
         $custom1 = $this->createMock(Definition::class);
         $custom1
             ->expects(self::once())
+            ->method('getArguments')
+            ->willReturn([
+                ['url' => 'mysql:\\\\'],
+                new Reference('doctrine.dbal.custom1_connection.configuration'),
+                null,
+                [],
+            ])
+        ;
+        $custom1
+            ->expects(self::once())
             ->method('getArgument')
             ->with(3)
             ->willReturn(['test' => '_test', 'enum' => '_test'])
@@ -98,6 +119,16 @@ final class RegisterEnumTypePassTest extends TestCase
         ;
 
         $custom2 = $this->createMock(Definition::class);
+        $custom2
+            ->expects(self::once())
+            ->method('getArguments')
+            ->willReturn([
+                ['url' => 'mysql:\\\\'],
+                new Reference('doctrine.dbal.custom2_connection.configuration'),
+                null,
+                [],
+            ])
+        ;
         $custom2
             ->expects(self::once())
             ->method('getArgument')


### PR DESCRIPTION
* fixes #245

- Works with Doctrine bundle 2.16, 2.17 and 3.0 (tested locally)

https://github.com/doctrine/DoctrineBundle/blob/3.0.0/UPGRADE-2.17.md#connectionfactorycreateconnection-signature-change