### PR TITLE
#251 fix: resolve PHP 8.5 deprecation for null array offset

### DIFF
--- a/DBAL/Types/AbstractEnumType.php
+++ b/DBAL/Types/AbstractEnumType.php
@@ -69,7 +69,7 @@ abstract class AbstractEnumType extends Type
      */
     public function convertToPHPValue(mixed $value, AbstractPlatform $platform): mixed
     {
-        if (!isset(static::$choices[$value])) {
+        if (null === $value || !isset(static::$choices[$value])) {
             return $value;
         }
 


### PR DESCRIPTION
Add explicit null check before using value as array offset in convertToPHPValue() to avoid the "Using null as an array offset is deprecated" warning in PHP 8.5.

Fixes #251